### PR TITLE
Fix build against Vala 0.46.5

### DIFF
--- a/src/Services/TemplateService.vala
+++ b/src/Services/TemplateService.vala
@@ -36,7 +36,7 @@ namespace Alcadica.Services {
         protected abstract void on_file_write_end (TemplateFile file);
         public signal void on_creation_end (bool without_errors);
 
-        public TemplateService(string template_name, string base_dir) {
+        protected TemplateService(string template_name, string base_dir) {
             this.directories = new List<TemplateFile> ();
             this.files = new List<TemplateFile> ();
             this.base_dir = base_dir;


### PR DESCRIPTION
Fix the following error message is shown when building the app with valac 0.46.5:

```
../src/Services/TemplateService.vala:39.9-39.30: error: Creation method of abstract class cannot be public.
        public TemplateService(string template_name, string base_dir) {
        ^^^^^^^^^^^^^^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
```
